### PR TITLE
Overhaul edit command

### DIFF
--- a/src/main/java/seedu/tache/logic/commands/CompleteCommand.java
+++ b/src/main/java/seedu/tache/logic/commands/CompleteCommand.java
@@ -62,7 +62,7 @@ public class CompleteCommand extends Command {
             ReadOnlyTask taskToEdit = lastShownList.get(indexList.get(i));
             Task completedTask = createCompletedTask(taskToEdit);
             try {
-                model.updateTask(indexList.get(i), completedTask);
+                model.updateTask(taskToEdit, completedTask);
             } catch (UniqueTaskList.DuplicateTaskException dpe) {
                 throw new CommandException(MESSAGE_DUPLICATE_TASK);
             }

--- a/src/main/java/seedu/tache/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/tache/logic/commands/EditCommand.java
@@ -61,7 +61,7 @@ public class EditCommand extends Command {
         ReadOnlyTask taskToEdit = lastShownList.get(filteredTaskListIndex);
         Task editedTask = createEditedTask(taskToEdit, editTaskDescriptor);
         try {
-            model.updateTask(filteredTaskListIndex, editedTask);
+            model.updateTask(taskToEdit, editedTask);
         } catch (UniqueTaskList.DuplicateTaskException dpe) {
             throw new CommandException(MESSAGE_DUPLICATE_TASK);
         }

--- a/src/main/java/seedu/tache/model/Model.java
+++ b/src/main/java/seedu/tache/model/Model.java
@@ -31,7 +31,7 @@ public interface Model {
      *      another existing task in the list.
      * @throws IndexOutOfBoundsException if {@code filteredTaskListIndex} < 0 or >= the size of the filtered list.
      */
-    void updateTask(int filteredTaskListIndex, ReadOnlyTask editedTask)
+    void updateTask(ReadOnlyTask taskToEdit, ReadOnlyTask editedTask)
             throws UniqueTaskList.DuplicateTaskException;
 
     /** Returns the filtered task list as an {@code UnmodifiableObservableList<ReadOnlyTask>} */

--- a/src/main/java/seedu/tache/model/ModelManager.java
+++ b/src/main/java/seedu/tache/model/ModelManager.java
@@ -88,12 +88,11 @@ public class ModelManager extends ComponentManager implements Model {
     //@@author
 
     @Override
-    public void updateTask(int filteredTaskListIndex, ReadOnlyTask editedTask)
+    public void updateTask(ReadOnlyTask taskToUpdate, ReadOnlyTask editedTask)
             throws UniqueTaskList.DuplicateTaskException {
         assert editedTask != null;
 
-        int taskManagerIndex = filteredTasks.getSourceIndex(filteredTaskListIndex);
-        taskManager.updateTask(taskManagerIndex, editedTask);
+        taskManager.updateTask(taskToUpdate, editedTask);
         indicateTaskManagerChanged();
     }
 

--- a/src/main/java/seedu/tache/model/TaskManager.java
+++ b/src/main/java/seedu/tache/model/TaskManager.java
@@ -96,7 +96,7 @@ public class TaskManager implements ReadOnlyTaskManager {
      *      another existing task in the list.
      * @throws IndexOutOfBoundsException if {@code index} < 0 or >= the size of the list.
      */
-    public void updateTask(int index, ReadOnlyTask editedReadOnlyTask)
+    public void updateTask(ReadOnlyTask taskToUpdate, ReadOnlyTask editedReadOnlyTask)
             throws UniqueTaskList.DuplicateTaskException {
         assert editedReadOnlyTask != null;
 
@@ -105,7 +105,7 @@ public class TaskManager implements ReadOnlyTaskManager {
         // TODO: the tags master list will be updated even though the below line fails.
         // This can cause the tags master list to have additional tags that are not tagged to any task
         // in the task list.
-        tasks.updateTask(index, editedTask);
+        tasks.updateTask(taskToUpdate, editedTask);
     }
 
     /**

--- a/src/main/java/seedu/tache/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/tache/model/task/UniqueTaskList.java
@@ -49,10 +49,11 @@ public class UniqueTaskList implements Iterable<Task> {
      *      another existing task in the list.
      * @throws IndexOutOfBoundsException if {@code index} < 0 or >= the size of the list.
      */
-    public void updateTask(int index, ReadOnlyTask editedTask) throws DuplicateTaskException {
+    public void updateTask(ReadOnlyTask readOnlyTaskToUpdate, ReadOnlyTask editedTask) throws DuplicateTaskException {
         assert editedTask != null;
+        assert readOnlyTaskToUpdate instanceof Task;
 
-        Task taskToUpdate = internalList.get(index);
+        Task taskToUpdate = (Task) readOnlyTaskToUpdate;
         if (!taskToUpdate.equals(editedTask) && internalList.contains(editedTask)) {
             throw new DuplicateTaskException();
         }
@@ -61,7 +62,7 @@ public class UniqueTaskList implements Iterable<Task> {
         // TODO: The code below is just a workaround to notify observers of the updated task.
         // The right way is to implement observable properties in the Task class.
         // Then, TaskCard should then bind its text labels to those observable properties.
-        internalList.set(index, taskToUpdate);
+        internalList.set(internalList.indexOf(taskToUpdate), taskToUpdate);
     }
 
     /**


### PR DESCRIPTION
Old implementation of updateTask required the index to reference the old task being changed. This PR changes the argument of updateTask from an integer index to the Task itself.