### PR TITLE
Replaced PrettyTime-NLP with Natty. Fixed issue #114

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,8 @@ allprojects {
         compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"
         compile "com.google.guava:guava:$guavaVersion"
         compile 'org.ocpsoft.prettytime:prettytime:4.0.1.Final'
-        compile 'org.ocpsoft.prettytime:prettytime-nlp:4.0.0.Final'
         compile group: 'com.github.tulskiy', name: 'jkeymaster', version: '1.2'
+        compile 'com.joestelmach:natty:0.12'
 
         testCompile "junit:junit:$junitVersion"
         testCompile "org.testfx:testfx-core:$testFxVersion"

--- a/src/main/java/seedu/tache/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/tache/logic/parser/EditCommandParser.java
@@ -40,6 +40,9 @@ import seedu.tache.model.task.Name;
  */
 public class EditCommandParser {
 
+    public static final String MESSAGE_INVALID_PARAMETER = "Invalid parameter given. Valid parameters" +
+                                                   " include name, start_date, start_time, end_date, end_time and tags";
+
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
      * and returns an EditCommand object for execution.
@@ -92,7 +95,7 @@ public class EditCommandParser {
                                                                               .split(EDIT_PARAMETER_DELIMITER))));
                     break;
                 default:
-                    break;
+                    throw new IllegalValueException(MESSAGE_INVALID_PARAMETER);
                 }
             } catch (IllegalValueException ive) {
                 return new IncorrectCommand(ive.getMessage());

--- a/src/main/java/seedu/tache/model/task/DateTime.java
+++ b/src/main/java/seedu/tache/model/task/DateTime.java
@@ -7,40 +7,53 @@ import java.util.Date;
 import java.util.List;
 
 import org.ocpsoft.prettytime.PrettyTime;
-import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
+
+import com.joestelmach.natty.DateGroup;
+import com.joestelmach.natty.Parser;
 
 import seedu.tache.commons.exceptions.IllegalValueException;
 
 
 public class DateTime {
 
-    public static final String MESSAGE_DATE_CONSTRAINTS =
-            "Task date should only contain <CONSTRAINT>";
+    public static final String MESSAGE_DATE_CONSTRAINTS = "Unknown date format. It is recommended to "
+                                        + "interchangeably use the following few formats:"
+                                        + "\nMM-DD-YY hh:mm:ss or MM/DD/YY 10.30pm";
 
-    public final Date date;
+    private final Date date;
 
     /**
      * Validates given date.
      *
      * @throws IllegalValueException if given date string is invalid.
      */
-    public DateTime(String date) {
+    public DateTime(String date) throws IllegalValueException {
         assert date != null;
         String trimmedStartDate = date.trim();
-        List<Date> temp = new PrettyTimeParser().parse(trimmedStartDate);
-
-        /*if (!isValidDate(trimmedStartDate)) {
-            throw new IllegalValueException(MESSAGE_TIME_CONSTRAINTS);
-        }*/
-        this.date = temp.get(0);
+        List<DateGroup> temp = new Parser().parse(trimmedStartDate);
+        if (temp.isEmpty()) {
+            throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
+        }
+        this.date = temp.get(0).getDates().get(0);
+        String syntaxTree = temp.get(0).getSyntaxTree().toStringTree();
+        boolean hasExplicitDate = syntaxTree.contains("EXPLICIT_DATE");
+        boolean hasExplicitTime = syntaxTree.contains("EXPLICIT_TIME");
+        if (hasExplicitDate ^ hasExplicitTime) {
+            if (hasExplicitDate) {
+                this.date.setHours(0);
+                this.date.setMinutes(0);
+                this.date.setSeconds(0);
+            }
+        }
     }
 
     /**
      * Returns true if a given string is a valid task date.
      */
-    /*public static boolean isValidDate(String test) {
-        return test.matches(DATE_VALIDATION_REGEX);
-    }*/
+    public static boolean isValidDate(String test) {
+        List<DateGroup> temp = new Parser().parse(test);
+        return !temp.isEmpty();
+    }
 
     @Override
     public String toString() {
@@ -52,13 +65,18 @@ public class DateTime {
         return sdf.format(date);
     }
 
+    public String getTimeOnly() {
+        SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss");
+        return sdf.format(date);
+    }
+
     public String getAmericanDateTime() {
         SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
         return sdf.format(date);
     }
 
-    public String getTimeOnly() {
-        SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss");
+    public String getAmericanDateOnly() {
+        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy");
         return sdf.format(date);
     }
 

--- a/src/main/java/seedu/tache/model/task/DateTime.java
+++ b/src/main/java/seedu/tache/model/task/DateTime.java
@@ -47,14 +47,6 @@ public class DateTime {
         }
     }
 
-    /**
-     * Returns true if a given string is a valid task date.
-     */
-    public static boolean isValidDate(String test) {
-        List<DateGroup> temp = new Parser().parse(test);
-        return !temp.isEmpty();
-    }
-
     @Override
     public String toString() {
         return new PrettyTime().format(date);


### PR DESCRIPTION
Replaced PrettyTime-NLP with Natty due to functional limitations of PrettyTime-NLP. All prior functions of PrettyTime-NLP remains and is supported by Natty. 
Default time is now set to 00:00:00 if none is specified.