### PR TITLE
Revamped Edit NLP

### DIFF
--- a/src/main/java/seedu/tache/logic/commands/CompleteCommand.java
+++ b/src/main/java/seedu/tache/logic/commands/CompleteCommand.java
@@ -69,7 +69,7 @@ public class CompleteCommand extends Command implements Undoable {
             Task completedTask = createCompletedTask(taskToEdit);
             try {
                 if (taskToEdit.getRecurringStatus()) {
-                    model.updateTask(createOriginalRecurringTask(taskToEdit), completedTask);
+                    model.updateTask(createMasterRecurringTask(taskToEdit), completedTask);
                 } else {
                     model.updateTask(taskToEdit, completedTask);
                 }
@@ -124,7 +124,7 @@ public class CompleteCommand extends Command implements Undoable {
      * Creates and returns a {@code Task} with the details of {@code taskToEdit}
      * edited with {@code editTaskDescriptor}.
      */
-    private static Task createOriginalRecurringTask(ReadOnlyTask taskToEdit) {
+    private static Task createMasterRecurringTask(ReadOnlyTask taskToEdit) {
         assert taskToEdit != null;
         ((Task) taskToEdit).setRecurDisplayDate("");
         return new Task(taskToEdit.getName(), taskToEdit.getStartDateTime(), taskToEdit.getEndDateTime(),

--- a/src/main/java/seedu/tache/logic/commands/CompleteCommand.java
+++ b/src/main/java/seedu/tache/logic/commands/CompleteCommand.java
@@ -81,8 +81,8 @@ public class CompleteCommand extends Command implements Undoable {
         }
         commandSuccess = true;
         undoHistory.push(this);
-        model.updateCurrentFilteredList();
-        model.getFilteredTaskList();
+        //model.updateCurrentFilteredList();
+        //model.getFilteredTaskList();
 
         return new CommandResult(String.format(MESSAGE_COMPLETED_TASK_SUCCESS, getSuccessMessage(completedList)));
     }

--- a/src/main/java/seedu/tache/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/tache/logic/commands/EditCommand.java
@@ -90,7 +90,7 @@ public class EditCommand extends Command implements Undoable {
             } catch (UniqueTaskList.DuplicateTaskException dpe) {
                 throw new CommandException(MESSAGE_DUPLICATE_TASK);
             }
-            model.updateCurrentFilteredList();
+            //model.updateCurrentFilteredList();
             commandSuccess = true;
             undoHistory.push(this);
             EventsCenter.getInstance().post(new JumpToListRequestEvent(model.getFilteredTaskListIndex(taskToEdit)));

--- a/src/main/java/seedu/tache/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/tache/logic/parser/CliSyntax.java
@@ -16,8 +16,11 @@ public class CliSyntax {
     /* Natural Language Processing definitions */
     public static final String KEYWORD_EDIT_PARAMETER = " change ";
     public static final String KEYWORD_EDIT_PARAMETER_VALUE = " to ";
+    public static final String KEYWORD_EDIT_PARAMETER_VALUE_TEST = "to";
     public static final String KEYWORD_EDIT_MULTI_PARAMETER = " and ";
     public static final String KEYWORDS_EDIT_MULTI_PARAMETER = " and change ";
+    public static final String KEYWORD_EDIT_PARAMETER_TEST = "change";
+    public static final String KEYWORD_EDIT_MULTI_PARAMETER_TEST = "and";
 
     /* Parameter names definitions */
     public static final String PARAMETER_NAME = "name";

--- a/src/main/java/seedu/tache/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/tache/logic/parser/CliSyntax.java
@@ -14,13 +14,9 @@ public class CliSyntax {
     public static final String DELIMITER_EDIT_PARAMETER = new String(" ");
 
     /* Natural Language Processing definitions */
-    public static final String KEYWORD_EDIT_PARAMETER = " change ";
-    public static final String KEYWORD_EDIT_PARAMETER_VALUE = " to ";
-    public static final String KEYWORD_EDIT_PARAMETER_VALUE_TEST = "to";
-    public static final String KEYWORD_EDIT_MULTI_PARAMETER = " and ";
-    public static final String KEYWORDS_EDIT_MULTI_PARAMETER = " and change ";
-    public static final String KEYWORD_EDIT_PARAMETER_TEST = "change";
-    public static final String KEYWORD_EDIT_MULTI_PARAMETER_TEST = "and";
+    public static final String KEYWORD_EDIT_PARAMETER_VALUE = "to";
+    public static final String KEYWORD_EDIT_PARAMETER = "change";
+    public static final String KEYWORD_EDIT_MULTI_PARAMETER = "and";
 
     /* Parameter names definitions */
     public static final String PARAMETER_NAME = "name";

--- a/src/main/java/seedu/tache/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/tache/logic/parser/EditCommandParser.java
@@ -6,13 +6,15 @@ import static seedu.tache.logic.parser.CliSyntax.DELIMITER_EDIT_PARAMETER;
 import static seedu.tache.logic.parser.CliSyntax.DELIMITER_PARAMETER;
 import static seedu.tache.logic.parser.CliSyntax.KEYWORDS_EDIT_MULTI_PARAMETER;
 import static seedu.tache.logic.parser.CliSyntax.KEYWORD_EDIT_MULTI_PARAMETER;
+import static seedu.tache.logic.parser.CliSyntax.KEYWORD_EDIT_MULTI_PARAMETER_TEST;
 import static seedu.tache.logic.parser.CliSyntax.KEYWORD_EDIT_PARAMETER;
+import static seedu.tache.logic.parser.CliSyntax.KEYWORD_EDIT_PARAMETER_TEST;
 import static seedu.tache.logic.parser.CliSyntax.KEYWORD_EDIT_PARAMETER_VALUE;
+import static seedu.tache.logic.parser.CliSyntax.KEYWORD_EDIT_PARAMETER_VALUE_TEST;
 import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_DATE;
 import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_DATE_2;
 import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_DATE_3;
 import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_TIME;
-
 import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_TIME_2;
 import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_TIME_3;
 import static seedu.tache.logic.parser.CliSyntax.PARAMETER_NAME;
@@ -77,11 +79,12 @@ public class EditCommandParser {
 
             //Process Other Arguments
             int indexOfFirstAndChange = argsInProcess.indexOf(KEYWORDS_EDIT_MULTI_PARAMETER);
-            if (indexOfFirstAndChange == -1) {
-                return processNaturalSingleParameterEdit(index, argsInProcess);
-            } else {
-                return processNaturalMultiParameterEdit(index, indexOfFirstAndChange, argsInProcess);
-            }
+            //if (indexOfFirstAndChange == -1) {
+                //return processNaturalSingleParameterEdit(index, argsInProcess);
+            //} else {
+                //return processNaturalMultiParameterEdit(index, indexOfFirstAndChange, argsInProcess);
+                return processNaturalMultiParameterEdit2(index, argsInProcess);
+            //}
         } else {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditCommand.MESSAGE_USAGE));
@@ -209,6 +212,64 @@ public class EditCommandParser {
                         EditCommand.MESSAGE_USAGE));
             }
         }
+        String structuredArgument = index.get() + DELIMITER_PARAMETER;
+        for (int i = 0; i < updateParameterList.size(); i++) {
+            structuredArgument += updateParameterList.get(i) + DELIMITER_EDIT_PARAMETER
+                                + updateValueList.get(i) + DELIMITER_EDIT_PARAMETER + DELIMITER_PARAMETER;
+        }
+        return parseStructuredArguments(structuredArgument);
+    }
+
+    /**
+     * Process the given {@code String} of arguments that contains only multiple parameters of interest
+     * that is of a natural language format and returns an EditCommand object for execution.
+     */
+    private Command processNaturalMultiParameterEdit2 (Optional<Integer> index, String argsInProcess) {
+        String[] argsInProcessElements = argsInProcess.trim().split(DELIMITER_EDIT_PARAMETER);
+        ArrayList<String> updateParameterList = new ArrayList<String>();
+        ArrayList<String> updateValueList = new ArrayList<String>();
+
+        if (!argsInProcessElements[0].equals(KEYWORD_EDIT_PARAMETER_TEST)) {
+            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditCommand.MESSAGE_USAGE));
+        }
+
+        boolean processingParameter = false;
+        String currentParameter = "";
+        String currentValue = "";
+        for (int i = 1; i < argsInProcessElements.length; i++) {
+            if (ParserUtil.isValidParameter(argsInProcessElements[i]) && !processingParameter) {
+                if (argsInProcessElements[i + 1] != null
+                        && argsInProcessElements[i + 1].equals(KEYWORD_EDIT_PARAMETER_VALUE_TEST)) {
+                    processingParameter = true;
+                    currentParameter = argsInProcessElements[i];
+                    i++;
+                    continue;
+                }
+            }
+            if (processingParameter) {
+                //Parameter Value Termination Condition Check
+                if (argsInProcessElements[i].equals(KEYWORD_EDIT_MULTI_PARAMETER_TEST)
+                        && (i + 1 < argsInProcessElements.length)
+                        && ParserUtil.isValidParameter(argsInProcessElements[i + 1])
+                        && (i + 2 < argsInProcessElements.length)
+                        && argsInProcessElements[i + 2].equals(KEYWORD_EDIT_PARAMETER_VALUE_TEST)) {
+                    processingParameter = false;
+                    updateParameterList.add(currentParameter);
+                    updateValueList.add(currentValue.trim());
+                    currentValue = "";
+                } else if (i + 1 == argsInProcessElements.length) {
+                    currentValue += " " + argsInProcessElements[i];
+                    processingParameter = false;
+                    updateParameterList.add(currentParameter);
+                    updateValueList.add(currentValue.trim());
+                    currentValue = "";
+                } else {
+                    currentValue += " " + argsInProcessElements[i];
+                }
+            }
+        }
+
         String structuredArgument = index.get() + DELIMITER_PARAMETER;
         for (int i = 0; i < updateParameterList.size(); i++) {
             structuredArgument += updateParameterList.get(i) + DELIMITER_EDIT_PARAMETER

--- a/src/main/java/seedu/tache/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/tache/logic/parser/EditCommandParser.java
@@ -4,13 +4,9 @@ package seedu.tache.logic.parser;
 import static seedu.tache.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.tache.logic.parser.CliSyntax.DELIMITER_EDIT_PARAMETER;
 import static seedu.tache.logic.parser.CliSyntax.DELIMITER_PARAMETER;
-import static seedu.tache.logic.parser.CliSyntax.KEYWORDS_EDIT_MULTI_PARAMETER;
 import static seedu.tache.logic.parser.CliSyntax.KEYWORD_EDIT_MULTI_PARAMETER;
-import static seedu.tache.logic.parser.CliSyntax.KEYWORD_EDIT_MULTI_PARAMETER_TEST;
 import static seedu.tache.logic.parser.CliSyntax.KEYWORD_EDIT_PARAMETER;
-import static seedu.tache.logic.parser.CliSyntax.KEYWORD_EDIT_PARAMETER_TEST;
 import static seedu.tache.logic.parser.CliSyntax.KEYWORD_EDIT_PARAMETER_VALUE;
-import static seedu.tache.logic.parser.CliSyntax.KEYWORD_EDIT_PARAMETER_VALUE_TEST;
 import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_DATE;
 import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_DATE_2;
 import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_DATE_3;
@@ -77,14 +73,8 @@ public class EditCommandParser {
             int indexOfIndex = argsInProcess.indexOf(new String("" +  index.get()));
             argsInProcess = argsInProcess.substring(indexOfIndex + new String("" +  index.get()).length());
 
-            //Process Other Arguments
-            int indexOfFirstAndChange = argsInProcess.indexOf(KEYWORDS_EDIT_MULTI_PARAMETER);
-            //if (indexOfFirstAndChange == -1) {
-                //return processNaturalSingleParameterEdit(index, argsInProcess);
-            //} else {
-                //return processNaturalMultiParameterEdit(index, indexOfFirstAndChange, argsInProcess);
-                return processNaturalMultiParameterEdit2(index, argsInProcess);
-            //}
+            return processNaturalMultiParameterEdit(index, argsInProcess);
+
         } else {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditCommand.MESSAGE_USAGE));
@@ -155,81 +145,17 @@ public class EditCommandParser {
         return new EditCommand(index.get(), editTaskDescriptor);
     }
 
-    /**
-     * Process the given {@code String} of arguments that contains only one parameter of interest
-     * that is of a natural language format and returns an EditCommand object for execution.
-     */
-    private Command processNaturalSingleParameterEdit(Optional<Integer> index, String argsInProcess) {
-        int indexOfFirstChange = argsInProcess.indexOf(KEYWORD_EDIT_PARAMETER);
-        int indexOfFirstTo = argsInProcess.indexOf(KEYWORD_EDIT_PARAMETER_VALUE);
-        if (indexOfFirstChange != -1 && indexOfFirstTo != -1) {
-            String updateParameter = argsInProcess.substring(indexOfFirstChange
-                                        + new String(KEYWORD_EDIT_PARAMETER).length(), indexOfFirstTo);
-            String updateValue = argsInProcess.substring(indexOfFirstTo
-                                        + new String(KEYWORD_EDIT_PARAMETER_VALUE).length());
-            return parseStructuredArguments(index.get() + DELIMITER_PARAMETER + updateParameter
-                                                + DELIMITER_EDIT_PARAMETER + updateValue);
-        } else {
-            if (indexOfFirstChange == -1 && indexOfFirstTo == -1) {
-                return new IncorrectCommand(EditCommand.MESSAGE_NOT_EDITED);
-            }
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    EditCommand.MESSAGE_USAGE));
-        }
-    }
 
     /**
      * Process the given {@code String} of arguments that contains only multiple parameters of interest
      * that is of a natural language format and returns an EditCommand object for execution.
      */
-    private Command processNaturalMultiParameterEdit (Optional<Integer> index,
-                                int indexOfFirstAndChange, String argsInProcess) {
-        int currentIndexOfFirstAndChange = indexOfFirstAndChange;
-        ArrayList<String> updateParameterList = new ArrayList<String>();
-        ArrayList<String> updateValueList = new ArrayList<String>();
-        while (argsInProcess.length() > 0) {
-            int indexOfFirstChange = argsInProcess.indexOf(KEYWORD_EDIT_PARAMETER);
-            int indexOfFirstTo = argsInProcess.indexOf(KEYWORD_EDIT_PARAMETER_VALUE);
-            if (indexOfFirstChange != -1 && indexOfFirstTo != -1) {
-                String updateParameter = argsInProcess.substring(indexOfFirstChange
-                        + new String(KEYWORD_EDIT_PARAMETER).length(), indexOfFirstTo);
-                String updateValue = "";
-                if (currentIndexOfFirstAndChange != -1) {
-                    updateValue = argsInProcess.substring(indexOfFirstTo
-                            + new String(KEYWORD_EDIT_PARAMETER_VALUE).length(), currentIndexOfFirstAndChange);
-                    argsInProcess = argsInProcess.substring(currentIndexOfFirstAndChange
-                            + new String(KEYWORD_EDIT_MULTI_PARAMETER).length() - 1);
-                    currentIndexOfFirstAndChange = argsInProcess.indexOf(KEYWORDS_EDIT_MULTI_PARAMETER);
-                } else {
-                    updateValue = argsInProcess.substring(indexOfFirstTo
-                                    + new String(KEYWORD_EDIT_PARAMETER_VALUE).length());
-                    argsInProcess = "";
-                }
-                updateParameterList.add(updateParameter);
-                updateValueList.add(updateValue);
-            } else {
-                return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                        EditCommand.MESSAGE_USAGE));
-            }
-        }
-        String structuredArgument = index.get() + DELIMITER_PARAMETER;
-        for (int i = 0; i < updateParameterList.size(); i++) {
-            structuredArgument += updateParameterList.get(i) + DELIMITER_EDIT_PARAMETER
-                                + updateValueList.get(i) + DELIMITER_EDIT_PARAMETER + DELIMITER_PARAMETER;
-        }
-        return parseStructuredArguments(structuredArgument);
-    }
-
-    /**
-     * Process the given {@code String} of arguments that contains only multiple parameters of interest
-     * that is of a natural language format and returns an EditCommand object for execution.
-     */
-    private Command processNaturalMultiParameterEdit2 (Optional<Integer> index, String argsInProcess) {
+    private Command processNaturalMultiParameterEdit (Optional<Integer> index, String argsInProcess) {
         String[] argsInProcessElements = argsInProcess.trim().split(DELIMITER_EDIT_PARAMETER);
         ArrayList<String> updateParameterList = new ArrayList<String>();
         ArrayList<String> updateValueList = new ArrayList<String>();
 
-        if (!argsInProcessElements[0].equals(KEYWORD_EDIT_PARAMETER_TEST)) {
+        if (!argsInProcessElements[0].equals(KEYWORD_EDIT_PARAMETER)) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditCommand.MESSAGE_USAGE));
         }
@@ -240,7 +166,7 @@ public class EditCommandParser {
         for (int i = 1; i < argsInProcessElements.length; i++) {
             if (ParserUtil.isValidParameter(argsInProcessElements[i]) && !processingParameter) {
                 if (argsInProcessElements[i + 1] != null
-                        && argsInProcessElements[i + 1].equals(KEYWORD_EDIT_PARAMETER_VALUE_TEST)) {
+                        && argsInProcessElements[i + 1].equals(KEYWORD_EDIT_PARAMETER_VALUE)) {
                     processingParameter = true;
                     currentParameter = argsInProcessElements[i];
                     i++;
@@ -248,12 +174,11 @@ public class EditCommandParser {
                 }
             }
             if (processingParameter) {
-                //Parameter Value Termination Condition Check
-                if (argsInProcessElements[i].equals(KEYWORD_EDIT_MULTI_PARAMETER_TEST)
+                if (argsInProcessElements[i].equals(KEYWORD_EDIT_MULTI_PARAMETER)
                         && (i + 1 < argsInProcessElements.length)
                         && ParserUtil.isValidParameter(argsInProcessElements[i + 1])
                         && (i + 2 < argsInProcessElements.length)
-                        && argsInProcessElements[i + 2].equals(KEYWORD_EDIT_PARAMETER_VALUE_TEST)) {
+                        && argsInProcessElements[i + 2].equals(KEYWORD_EDIT_PARAMETER_VALUE)) {
                     processingParameter = false;
                     updateParameterList.add(currentParameter);
                     updateValueList.add(currentValue.trim());

--- a/src/main/java/seedu/tache/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/tache/logic/parser/ParserUtil.java
@@ -1,5 +1,22 @@
 package seedu.tache.logic.parser;
 
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_DATE;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_DATE_2;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_DATE_3;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_TIME;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_TIME_2;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_END_TIME_3;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_NAME;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_NAME_2;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_START_DATE;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_START_DATE_2;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_START_DATE_3;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_START_TIME;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_START_TIME_2;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_START_TIME_3;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_TAG;
+import static seedu.tache.logic.parser.CliSyntax.PARAMETER_TAG_2;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -19,6 +36,7 @@ import seedu.tache.model.tag.Tag;
 import seedu.tache.model.tag.UniqueTagList;
 import seedu.tache.model.task.DateTime;
 import seedu.tache.model.task.Name;
+
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes
@@ -136,6 +154,34 @@ public class ParserUtil {
     public static boolean isValidName(String input) {
         final Matcher matcher = FORMAT_NAME.matcher(input.trim());
         return matcher.matches();
+    }
+
+    /**
+     * Returns True if input is a valid parameter
+     * Returns False otherwise.
+     */
+    public static boolean isValidParameter(String input) {
+        switch (input) {
+        case PARAMETER_NAME:
+        case PARAMETER_NAME_2:
+        case PARAMETER_START_DATE:
+        case PARAMETER_START_DATE_2:
+        case PARAMETER_START_DATE_3:
+        case PARAMETER_END_DATE:
+        case PARAMETER_END_DATE_2:
+        case PARAMETER_END_DATE_3:
+        case PARAMETER_START_TIME:
+        case PARAMETER_START_TIME_2:
+        case PARAMETER_START_TIME_3:
+        case PARAMETER_END_TIME:
+        case PARAMETER_END_TIME_2:
+        case PARAMETER_END_TIME_3:
+        case PARAMETER_TAG:
+        case PARAMETER_TAG_2:
+            return true;
+        default:
+            return false;
+        }
     }
     //@@author
     /**

--- a/src/main/java/seedu/tache/model/Model.java
+++ b/src/main/java/seedu/tache/model/Model.java
@@ -90,5 +90,5 @@ public interface Model {
 
     //@@author A0139925U
     /** Updates the filter of the current filtered task list to reflect changes */
-    void updateCurrentFilteredList();
+    //void updateCurrentFilteredList();
 }

--- a/src/main/java/seedu/tache/model/ModelManager.java
+++ b/src/main/java/seedu/tache/model/ModelManager.java
@@ -234,35 +234,35 @@ public class ModelManager extends ComponentManager implements Model {
         latestKeywords = keywords;
     }
 
-    public void updateCurrentFilteredList() {
-        switch(filteredTaskListType) {
-        case TASK_LIST_TYPE_ALL:
-            updateFilteredListToShowAll();
-            break;
-        case TASK_LIST_TYPE_COMPLETED:
-            updateFilteredListToShowCompleted();
-            break;
-        case TASK_LIST_TYPE_UNCOMPLETED:
-            updateFilteredListToShowUncompleted();
-            break;
-        case TASK_LIST_TYPE_TIMED:
-            updateFilteredListToShowTimed();
-            break;
-        case TASK_LIST_TYPE_FLOATING:
-            updateFilteredListToShowFloating();
-            break;
-        case TASK_LIST_TYPE_FOUND:
-            updateFilteredTaskList(latestKeywords);
-            break;
-        case TASK_LIST_TYPE_DUE_TODAY:
-            updateFilteredListToShowDueToday();
-            break;
-        case TASK_LIST_TYPE_DUE_THIS_WEEK:
-            updateFilteredListToShowDueThisWeek();
-            break;
-        default:
-        }
-    }
+//    public void updateCurrentFilteredList() {
+//        switch(filteredTaskListType) {
+//        case TASK_LIST_TYPE_ALL:
+//            updateFilteredListToShowAll();
+//            break;
+//        case TASK_LIST_TYPE_COMPLETED:
+//            updateFilteredListToShowCompleted();
+//            break;
+//        case TASK_LIST_TYPE_UNCOMPLETED:
+//            updateFilteredListToShowUncompleted();
+//            break;
+//        case TASK_LIST_TYPE_TIMED:
+//            updateFilteredListToShowTimed();
+//            break;
+//        case TASK_LIST_TYPE_FLOATING:
+//            updateFilteredListToShowFloating();
+//            break;
+//        case TASK_LIST_TYPE_FOUND:
+//            updateFilteredTaskList(latestKeywords);
+//            break;
+//        case TASK_LIST_TYPE_DUE_TODAY:
+//            updateFilteredListToShowDueToday();
+//            break;
+//        case TASK_LIST_TYPE_DUE_THIS_WEEK:
+//            updateFilteredListToShowDueThisWeek();
+//            break;
+//        default:
+//        }
+//    }
     //@@author
 
     //========== Inner classes/interfaces/methods used for filtering =================================================


### PR DESCRIPTION
OLD Format: edit `<index>` change `<parameter>` to `<value>` and **change** `<parameter>` to `<value>`
OLD Limitation: certain keywords cannot be used in concurrent with name edits (e.g change, and, to, etc.)

NEW Format: edit `<index>` change `<parameter>` to `<value>` and `<parameter>` to `<value>`
NEW Limitation: None